### PR TITLE
Assign window panel property in draggable component

### DIFF
--- a/StorageAsBag.cs
+++ b/StorageAsBag.cs
@@ -391,6 +391,8 @@ namespace PantheonStorageAsBagMod
             // Add window panel components
             _uiDraggable = _storageBag.AddComponent<UIDraggable>();
             _uiWindowPanel = _storageBag.AddComponent<UIWindowPanel>();
+            _uiDraggable._windowPanel = _uiWindowPanel;
+            
             var canvasGroup = _storageBag.AddComponent<CanvasGroup>();
             _storageBag.AddComponent<BagPositionSaver>();
             _uiWindowPanel.CanvasGroup = canvasGroup;


### PR DESCRIPTION
`UIDraggable` has a `_windowPanel` property that is set to the `UIWindowPanel` component on the same object. All draggable components that I've seen have this set, so the addon framework assumes it'll be there, but this leads to the following exception.

```
[12:24:01.134] [Il2CppInterop] During invoking native->managed trampoline
System.NullReferenceException: Object reference not set to an instance of an object.
   at PantheonAddonLoader.UI.AddonWindow..ctor(UIWindowPanel window)
   at PantheonAddonLoader.Hooks.RectTransformHooks.Postfix(UIDraggable __instance)
   at DMD<Il2Cpp.UIDraggable::OnDrag>(UIDraggable this, PointerEventData eventData)
   at (il2cpp -> managed) OnDrag(IntPtr , IntPtr , Il2CppMethodInfo* )
```